### PR TITLE
Fixed error in schedule when link was empty

### DIFF
--- a/src/components/Slot/OtherSlot.js
+++ b/src/components/Slot/OtherSlot.js
@@ -7,8 +7,8 @@ const OtherSlot = ({ collection }) => {
     <div className="slot white-background">
       <span className="time">{collection.time}</span>
       <div className="title">
-        {collection.link.length > 0 ? (
-            <a href={collection.link}>{collection.title}</a>
+        {collection.link && collection.link.length > 0 ? (
+          <a href={collection.link}>{collection.title}</a>
           ) : (
             <span>{collection.title}</span>
           )


### PR DESCRIPTION
Added check to verify that collection.link is not null before checking .length